### PR TITLE
fix: Adds npm eslint as local dependency

### DIFF
--- a/node-settings.ts
+++ b/node-settings.ts
@@ -11,7 +11,11 @@ export const nodeExtensions: Extension[] = [
 ];
 
 export const gitNodePrecommitCmd: GitCommitCheckSettings = `#!/bin/zsh
-npm run lint`;
+eslint . --ext .ts`;
+
+export const nodeESlintTSDependency = `npm install typescript --save-dev`;
+export const nodeESLint =
+  `npm install eslint @typescript-eslint/parser @typescript-eslint/eslint-plugin --save-dev`;
 
 export interface NodeESLintSettings {
   "root": true;

--- a/project.ts
+++ b/project.ts
@@ -505,6 +505,7 @@ export interface NodeProject extends ProjectPath {
     settingsFileName: AbsoluteFsPathAndFileName;
     extensionsFileName: AbsoluteFsPathAndFileName;
     tsConfigPath: AbsoluteFsPath;
+    pkgConfigPath: AbsoluteFsPath;
     esLintSettings: AbsoluteFsPathAndFileName;
     esLintIgnore: AbsoluteFsPathAndFileName;
     settingsExists: () => boolean;
@@ -536,6 +537,7 @@ export function enrichNodeProject(
   const configSettingsFileName = `${configPath}/settings.json`;
   const configExtnFileName = `${configPath}/extensions.json`;
   const tsConfigPath = path.join(projectPath, "tsconfig.json");
+  const pkgConfigPath = path.join(projectPath, "package.json");
   const esLintSettingsPath = `${pp.absProjectPath}/.eslintrc`;
   const esLintIgnorePath = `${pp.absProjectPath}/.eslintignore`;
   if (
@@ -550,6 +552,7 @@ export function enrichNodeProject(
       settingsFileName: configSettingsFileName,
       extensionsFileName: configExtnFileName,
       tsConfigPath: tsConfigPath,
+      pkgConfigPath: pkgConfigPath,
       esLintSettings: esLintSettingsPath,
       esLintIgnore: esLintIgnorePath,
       configPathExists: (): boolean => {

--- a/projectctl.ts
+++ b/projectctl.ts
@@ -313,6 +313,8 @@ export async function nodeSetupOrUpgradeProjectHandler(
       if (!isDryRun(options)) {
         startPP.nodeConfig.writeSettings(mod.nodeSettings);
         startPP.nodeConfig.writeExtensions(mod.nodeExtensions);
+        await runShellCommand(mod.nodeESlintTSDependency, startPP, options);
+        await runShellCommand(mod.nodeESLint, startPP, options);
         startPP.nodeConfig.writeLintSettings(
           mod.nodeESLintSettings,
           mod.nodeESLintIgnoreDirs,


### PR DESCRIPTION
This adds npm eslint as a local dependency rather than changes made global to developer environment.